### PR TITLE
add webresource capability to easse

### DIFF
--- a/osgi.enroute.easse.simple.adapter/bnd.bnd
+++ b/osgi.enroute.easse.simple.adapter/bnd.bnd
@@ -16,6 +16,12 @@ Private-Package:  \
 	osgi.enroute.easse.simple.adapter
 
 Conditional-Package: aQute.lib*
+
+Provide-Capability: 	\
+	osgi.enroute.webresource; \
+		osgi.enroute.webresource=/osgi/enroute/easse; \
+		root=/static/osgi/enroute/easse; \
+		version:Version=${Bundle-Version}
 	
 -buildpath:  \
 	osgi.enroute.base.api;version=1.0,\

--- a/osgi.enroute.easse.simple.adapter/src/osgi/enroute/easse/simple/adapter/ServerSideEventImpl.java
+++ b/osgi.enroute.easse.simple.adapter/src/osgi/enroute/easse/simple/adapter/ServerSideEventImpl.java
@@ -55,7 +55,7 @@ import aQute.lib.json.JSONCodec;
  */
 @ProvideCapability(ns = EndpointNamespace.NS, name = "/sse/1", version = "1.1.0", effective = "active")
 @ServletWhiteboard
-@Component(name = "osgi.eventadmin.sse", properties = "alias=/sse/1", provide = Servlet.class, configurationPolicy = ConfigurationPolicy.require)
+@Component(name = "osgi.eventadmin.sse", properties = "alias=/sse/1", provide = Servlet.class, configurationPolicy = ConfigurationPolicy.optional)
 public class ServerSideEventImpl extends HttpServlet {
 	private static final long serialVersionUID = 1L;
 	private static JSONCodec codec = new JSONCodec();


### PR DESCRIPTION
Add a webresource Provide-Capability to the easse bundle. This avoids having to specify the easse .js files in html and use the webresource mechanism instead. 

To import those, one should add the following requirement to the client bundle though:

```Require-Capability: \
	osgi.enroute.webresource;resource:List<String>="easse.js,polyfill/eventsource.js";priority:Long=100;filter:="(&(osgi.enroute.webresource=/osgi/enroute/easse)(&(version>=1.3.0)(!(version>=2.0.0))))"```

Can this be added automatically with the ```@EventAdminSSEEndpoint``` annotation? Didn't find immediately where/how to add this?
