### PR TITLE
allow to cast the post/put data as additional parameter in the call instead of using _body() method

### DIFF
--- a/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestMapper.java
+++ b/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestMapper.java
@@ -233,17 +233,19 @@ public class RestMapper {
 	 */
 	public synchronized void addResource(REST resource) {
 		for (Method m : resource.getClass().getMethods()) {
-			// restrict to public methods
-			if(!Modifier.isPublic(m.getModifiers())){
-				continue;
-			}
-			// don't expose Object.class methods
-			if(m.getDeclaringClass().equals(Object.class)){
-				continue;
-			}
 
-			Function f = new Function(resource, m);
-			functions.add(f.getName(), f);
+			// restrict to methods starting with HTTP request prefix
+			String methodName = m.getName();
+			if(methodName.startsWith("get")
+				|| methodName.startsWith("post")
+				|| methodName.startsWith("put")
+				|| methodName.startsWith("delete")
+				|| methodName.startsWith("option")
+				|| methodName.startsWith("head")){
+			
+				Function f = new Function(resource, m);
+				functions.add(f.getName(), f);
+			}
 		}
 	}
 

--- a/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestMapper.java
+++ b/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestMapper.java
@@ -127,12 +127,12 @@ public class RestMapper {
 				// Ignore
 			}
 			// if method starts with put/post, and no _body method defined, 
-			// then convert payload data to last method parameter
-			// in this case the last parameter does not count for the cardinality
+			// then convert payload data to first method parameter after RestRequest
+			// in this case this parameter does not count for the cardinality
 			if(post==null && 
 					(m.getName().startsWith("put") 
 					|| m.getName().startsWith("post"))){
-				post = m.getParameterTypes()[noParams-1];
+				post = m.getParameterTypes()[1];
 				noParams--;
 				extraParam = true;
 			} else {
@@ -175,8 +175,8 @@ public class RestMapper {
 			Type[] types = method.getGenericParameterTypes();
 			parameters[0] = converter.convert(types[0], args);
 
-			for (int i = 1; i < cardinality; i++) {
-				if (varargs && i == cardinality - 1) {
+			for (int i = 1 + (extraParam ? 1 : 0); i < parameters.length; i++) {
+				if (varargs && i == parameters.length-1) {
 					parameters[i] = converter.convert(types[i], list);
 				} else {
 					// varargs but not enough to fill the constants
@@ -341,7 +341,7 @@ public class RestMapper {
 						Object arguments = codec.dec().from(rq.getInputStream()).get(type);
 						// use it as an extra argument
 						if(f.extraParam){
-							parameters[parameters.length-1] = arguments;
+							parameters[1] = arguments;
 						} else {
 							args.put("_body", arguments);
 						}

--- a/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestServlet.java
+++ b/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestServlet.java
@@ -32,7 +32,7 @@ import aQute.lib.json.*;
 	configurationPolicy = ConfigurationPolicy.optional, //
 	properties="alias=/rest"
 )
-public class RestServlet extends HttpServlet implements REST {
+public class RestServlet extends HttpServlet {
 	private static final long	serialVersionUID	= 1L;
 	final static JSONCodec		codec				= new JSONCodec();
 	RestMapper					mapper				= new RestMapper(null);
@@ -41,10 +41,6 @@ public class RestServlet extends HttpServlet implements REST {
 		boolean angular();
 
 		String alias();
-	}
-
-	public RestServlet() {
-		addREST(this);
 	}
 
 	Config	config;


### PR DESCRIPTION
In order to fetch the payload from a put/post call one requires to provide an own Options implementation with a _body() method. This is a quite cumbersome way to fetch this data. A nicer way is to use the converter to just convert the payload data to an additional parameter in the method.

For example suppose the method
```
   public void putXxx(PutRequest rq, UUID id) {
         MyDTO data = rq._body();
          // do stuff
   }
```
could be implemented as follows: 
```
   public void putXxx(RestRequest rq, UUID id, MyDTO data) {
          // do stuff
   }
```
My patch should support both scenarios: it checks whether the first argument has a _body() method, if yes, it uses the original way, if not, then it will try to use the last method parameter to convert the payload into.
