### PR TITLE
Export additional pi4j packages to use GpioPinListeners etc

### DIFF
--- a/osgi.enroute.iot.pi/provider.bnd
+++ b/osgi.enroute.iot.pi/provider.bnd
@@ -5,7 +5,11 @@
 	
 Export-Package: \
 	osgi.enroute.iot.pi.api,\
+	com.pi4j.io,\
 	com.pi4j.io.gpio,\
+	com.pi4j.io.gpio.event,\
+	com.pi4j.io.gpio.exception,\
+	com.pi4j.io.gpio.trigger,\
 	com.pi4j.system
 
 Private-Package: osgi.enroute.iot.pi.provider


### PR DESCRIPTION
For the IoT demo I had to export additional pi4j packages in order to be able to use GpioPinListeners etc for the micro switches. Maybe some additional pi4j packages should be exported as well?