### PR TITLE
Allow multiple configurations in a predifined order per Bundle-Configuration entry

### DIFF
--- a/osgi.enroute.configurer.simple.provider/src/osgi/enroute/configurer/simple/provider/Configurer.java
+++ b/osgi.enroute.configurer.simple.provider/src/osgi/enroute/configurer/simple/provider/Configurer.java
@@ -134,19 +134,24 @@ public class Configurer implements ConfigurationDone {
 							//
 							return null;
 
-						URL url = bundle.getEntry(h);
-						if (url == null) {
-							return null;
-						}
+						log.log(LogService.LOG_INFO, "Reading configurations for bundle "+bundle.getSymbolicName() + " " + bundle.getVersion()+" in " + h );
+						for (String entry : h.split(",")) {
+							URL url = bundle.getEntry(entry);
+							log.log(LogService.LOG_INFO, "Reading configuration for bundle "+bundle.getSymbolicName() + " " + bundle.getVersion()+" in " + entry + " " + url);
 
-						String s = IO.collect(url);
-						if (s == null) {
-							if ( defined )
-								log.log(LogService.LOG_INFO, "Cannot find configuration for bundle "+bundle.getSymbolicName() + " " + bundle.getVersion()+" in " + h + " " + url);
-							return null;
+							if (url == null) {
+								return null;
+							}
+	
+							String s = IO.collect(url);
+							if (s == null) {
+								if ( defined )
+									log.log(LogService.LOG_INFO, "Cannot find configuration for bundle "+bundle.getSymbolicName() + " " + bundle.getVersion()+" in " + h + " " + url);
+								return null;
+							}
+	
+							configure(bundle, s);
 						}
-
-						configure(bundle, s);
 					}
 					catch (IOException e) {
 						log.log(LogService.LOG_ERROR, "Failed to set configuration for " + bundle, e);


### PR DESCRIPTION
Reasoning: We want to let developers overwrite default configurations. initial configs are supplied via Bundle-Configuration=configuration/configuration.json for example.
Another configuration must come after that initial confiuration to allow safe overwrite behaviour (not depending on bundle startup order or anything).
A simple solution is to allow Bundle-Configuration accept a list of configuration paths as done in the patch with this commit.

An addional note: enRoute.configurer.extra works too for this usecase (as it comes after reading internal files from bundle) but its relading behavior is not desirable (never, because its executed in bndrun)