### PR TITLE
71 o.e.d.a.DTOs.Enc corrections 

### DIFF
--- a/osgi.enroute.dtos.bndlib.provider/src/osgi/enroute/dtos/bndlib/provider/DTOsProvider.java
+++ b/osgi.enroute.dtos.bndlib.provider/src/osgi/enroute/dtos/bndlib/provider/DTOsProvider.java
@@ -516,17 +516,17 @@ public class DTOsProvider implements DTOs {
 
 		@Override
 		public void put(OutputStream out) throws Exception {
-			codec.enc().charset("UTF-8").to(out).put(source);
+			this.put(out, "UTF-8");
 		}
 
 		@Override
 		public void put(OutputStream out, String charset) throws Exception {
-			enc.charset(charset).put(out);
+			enc.charset(charset).to(out).put(source);
 		}
 
 		@Override
 		public void put(Appendable out) throws Exception {
-			enc.put(out);
+			enc.to(out).put(source);
 		}
 
 		@Override

--- a/osgi.enroute.dtos.bndlib.provider/test/osgi/enroute/dtos/bndlib/provider/TestEncImpl.java
+++ b/osgi.enroute.dtos.bndlib.provider/test/osgi/enroute/dtos/bndlib/provider/TestEncImpl.java
@@ -1,0 +1,49 @@
+package osgi.enroute.dtos.bndlib.provider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.io.Writer;
+
+import org.osgi.framework.dto.BundleDTO;
+
+import junit.framework.TestCase;
+import osgi.enroute.dto.api.DTOs;
+
+/**
+ * Basic {@link Enc} test case.
+ */
+public class TestEncImpl extends TestCase {
+
+	private static final String EXPECTED_ENCODED_CONTENT = "{\"id\":999,\"symbolicName\":\"com.example.test\"}";
+	private static final BundleDTO bundleDTO = new BundleDTO();
+	static {
+		bundleDTO.id = 999;
+		bundleDTO.symbolicName = "com.example.test";
+	}
+
+	private DTOs.Enc cut;
+
+	public void setUp() throws Exception {
+		cut = new DTOsProvider().encoder(bundleDTO);
+	}
+
+	public void testAppendable() throws Exception {
+		try (Writer writer = new StringWriter()) {
+			cut.put(writer);
+			assertEquals(EXPECTED_ENCODED_CONTENT, writer.toString());
+		}
+	}
+
+	public void testOutputStream() throws Exception {
+		try (OutputStream os = new ByteArrayOutputStream()) {
+			cut.put(os);
+			assertEquals(EXPECTED_ENCODED_CONTENT, os.toString());
+		}
+		try (OutputStream os = new ByteArrayOutputStream()) {
+			cut.put(os, "UTF-8");
+			assertEquals(EXPECTED_ENCODED_CONTENT, os.toString());
+		}
+	}
+
+}

--- a/osgi.enroute.dtos.bndlib.provider/test/osgi/enroute/dtos/bndlib/provider/TestEncImpl.java
+++ b/osgi.enroute.dtos.bndlib.provider/test/osgi/enroute/dtos/bndlib/provider/TestEncImpl.java
@@ -11,11 +11,13 @@ import junit.framework.TestCase;
 import osgi.enroute.dto.api.DTOs;
 
 /**
- * Basic {@link Enc} test case.
+ * Minimal {@link DTOs.Enc} test case.
  */
 public class TestEncImpl extends TestCase {
 
 	private static final String EXPECTED_ENCODED_CONTENT = "{\"id\":999,\"symbolicName\":\"com.example.test\"}";
+	private static final String EXPECTED_PRETTY_ENCODED_CONTENT = "{\n\t\"id\":999,\"symbolicName\":\"com.example.test\"\n}";
+
 	private static final BundleDTO bundleDTO = new BundleDTO();
 	static {
 		bundleDTO.id = 999;
@@ -28,22 +30,37 @@ public class TestEncImpl extends TestCase {
 		cut = new DTOsProvider().encoder(bundleDTO);
 	}
 
-	public void testAppendable() throws Exception {
+	public void testPut() throws Exception {
+		assertEquals(EXPECTED_ENCODED_CONTENT, cut.put());
+	}
+
+	public void testPutToAppendable() throws Exception {
 		try (Writer writer = new StringWriter()) {
 			cut.put(writer);
 			assertEquals(EXPECTED_ENCODED_CONTENT, writer.toString());
 		}
 	}
 
-	public void testOutputStream() throws Exception {
+	public void testPutToOutputStream() throws Exception {
 		try (OutputStream os = new ByteArrayOutputStream()) {
 			cut.put(os);
 			assertEquals(EXPECTED_ENCODED_CONTENT, os.toString());
 		}
+	}
+
+	public void testPutToOutputStreamWithEncoding() throws Exception {
 		try (OutputStream os = new ByteArrayOutputStream()) {
 			cut.put(os, "UTF-8");
 			assertEquals(EXPECTED_ENCODED_CONTENT, os.toString());
 		}
+	}
+
+	public void testPretty() throws Exception {
+		assertEquals(EXPECTED_PRETTY_ENCODED_CONTENT, cut.pretty().put());
+	}
+
+	public void testIgnoreNull() throws Exception {
+		assertEquals(EXPECTED_ENCODED_CONTENT, cut.ignoreNull().put());
 	}
 
 }


### PR DESCRIPTION
Implementation for following methods in osgi.enroute.dtos.bndlib.provider.DTOsProvider.EncImpl:

- put(Appendable), 
- put(OutputStream, String)

were corrected. Implementation of put(OutputStream) delegates to put(OutputStream, String)
"minimal" Test included