### PR TITLE
Include jansi native libaries in osgi.enroute.gogo.shell.provider bundle

### DIFF
--- a/osgi.enroute.gogo.shell.provider/bnd.bnd
+++ b/osgi.enroute.gogo.shell.provider/bnd.bnd
@@ -23,5 +23,6 @@ Bundle-Description: \
 	org.apache.felix.gogo.shell.*, \
 	org.apache.felix.gogo.options
 
--includeresource: resources
+-includeresource: resources, \
+	@jline-2.14.2.jar!/META-INF/native/*
 


### PR DESCRIPTION
On Windows the native libraries of jansi weren't bundeled into the osgi bundle thats why osg.enroute.gogo.shell.provider failed on startup with the "java.lang.UnsatisfiedLinkError". This fix includes them. I have no idea if it's possible in bnd to write the include version neutral so we don't have the jline version hardcoded in the include resource statement.

Fixes issue #73 