### PR TITLE
Fix for #75 - set internal Config field on construction in RestServlet

### DIFF
--- a/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestServlet.java
+++ b/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestServlet.java
@@ -39,6 +39,7 @@ class RestServlet extends HttpServlet implements REST, Closeable {
 	final RestMapper			mapper;
 
 	RestServlet(Config config, String namespace) {
+		this.config = config;
 		corsEnabled = config.corsEnabled();
 		this.mapper = new RestMapper(namespace);
 	}


### PR DESCRIPTION
`RestServlet`'s internal config field is now correctly initialized using constructor's parameter. 