### PR TITLE
Fix for #83 sort functions inside existing synchronized block.

### DIFF
--- a/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestMapper.java
+++ b/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestMapper.java
@@ -156,6 +156,9 @@ public class RestMapper {
 
 			Function function = new Function(resource, m, verb, path, ranking);
 			functions.add(function.getName(), function);
+
+			Collections.sort(functions.get(function.getName()),
+					(a, b) -> Integer.compare(a.ranking, b.ranking));
 		}
 		endpoints.add(resource);
 	}
@@ -258,9 +261,6 @@ public class RestMapper {
 			if (candidates == null || candidates.isEmpty())
 				throw new FileNotFoundException("No such method " + name + "/"
 						+ cardinality + ". Available: " + functions);
-
-			Collections.sort(candidates,
-					(a, b) -> Integer.compare(a.ranking, b.ranking));
 
 			//
 			// All values are arrays, turn them into singletons when


### PR DESCRIPTION
Rankings of exposed functions on the REST mapper are treated as final so
they can be sorted when added rather than for each request.

Signed-off-by: Elias N Vasylenko <eliasvasylenko@gmail.com>