### PR TITLE
Simple response to feature request #68, enable primary rest endpoint.

### DIFF
--- a/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/Function.java
+++ b/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/Function.java
@@ -122,6 +122,10 @@ class Function {
 			hasPayloadAsParameter = false;
 		}
 
+		if (path.equals("/") && cardinality > 0)
+			throw new IllegalArgumentException("Invalid " + verb
+					+ " method " + method.getName() + ". A method on the root path cannot have a non-zero cardinality.");
+
 		this.post = requestBody;
 
 		this.cardinality = cardinality;

--- a/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestMapper.java
+++ b/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestMapper.java
@@ -193,7 +193,7 @@ public class RestMapper {
 		//
 		// Skip last _ so we can escape keywords
 		//
-		if (sb.charAt(sb.length() - 1) == '-')
+		if (sb.length() > 0 && sb.charAt(sb.length() - 1) == '-')
 			sb.setLength(sb.length() - 1);
 		return sb.toString();
 	}
@@ -229,10 +229,8 @@ public class RestMapper {
 		try {
 			String path = rq.getPathInfo();
 			if (path == null)
-				throw new IllegalArgumentException(
-						"The rest servlet requires that the name of the resource follows the servlet path ('rest'), like /rest/aQute.service.library.Program[/...]*[?...]");
-
-			if (path.startsWith("/"))
+				path = "";
+			else if (path.startsWith("/"))
 				path = path.substring(1);
 
 			if (path.equals("openapi.json")) {

--- a/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestServlet.java
+++ b/osgi.enroute.rest.simple.provider/src/osgi/enroute/rest/simple/provider/RestServlet.java
@@ -49,14 +49,6 @@ class RestServlet extends HttpServlet implements REST, Closeable {
 	}
 
 	public void service(HttpServletRequest rq, HttpServletResponse rsp) throws IOException, ServletException {
-		String pathInfo = rq.getPathInfo();
-		if (pathInfo == null) {
-			rsp.getWriter().println(
-					"The rest servlet requires that the name of the resource follows the servlet path ('rest'), like /rest/aQute.service.library.Program[/...]*[?...]");
-			rsp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-			return;
-		}
-
 		if (corsEnabled) {
 			addCorsHeaders(rsp);
 		}


### PR DESCRIPTION
If a method is named for the verb with no path given, provide from the
root endpoint.

Signed-off-by: Elias N Vasylenko <eliasvasylenko@gmail.com>